### PR TITLE
Update forgeSubmit query, add version_number docs

### DIFF
--- a/csharp/AnvilExamples.csproj
+++ b/csharp/AnvilExamples.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Anvil" Version="0.3.0" />
+    <PackageReference Include="Anvil" Version="0.5.0" />
   </ItemGroup>
 
 </Project>

--- a/csharp/Program.cs
+++ b/csharp/Program.cs
@@ -49,6 +49,12 @@ public class Program
         // Get your API key from your Anvil organization settings.
         // See https://www.useanvil.com/docs/api/getting-started#api-key for more details.
         var apiKey = Environment.GetEnvironmentVariable("ANVIL_API_KEY");
+
+        if (apiKey == null)
+        {
+            throw new Exception("API key must be provided");
+        }
+
         var programToRun = args[0];
         string? otherArgs = null;
 
@@ -60,7 +66,12 @@ public class Program
         var found = programsList.Find(obj => obj.Name.Equals(programToRun));
         if (found != null)
         {
-            var runnable = (RunnableBaseExample) Activator.CreateInstance(found.Klass, apiKey);
+            var runnable = (RunnableBaseExample) Activator.CreateInstance(found.Klass)!;
+
+            if (runnable == null)
+            {
+                throw new Exception("Unable to run example");
+            }
 
             if (otherArgs == null)
             {

--- a/csharp/Program.cs
+++ b/csharp/Program.cs
@@ -50,7 +50,12 @@ public class Program
         // See https://www.useanvil.com/docs/api/getting-started#api-key for more details.
         var apiKey = Environment.GetEnvironmentVariable("ANVIL_API_KEY");
         var programToRun = args[0];
-        var otherArgs = args[1];
+        string? otherArgs = null;
+
+        if (args.Length > 1)
+        {
+            otherArgs = args[1];
+        }
 
         var found = programsList.Find(obj => obj.Name.Equals(programToRun));
         if (found != null)

--- a/csharp/examples/FillPdf.cs
+++ b/csharp/examples/FillPdf.cs
@@ -96,14 +96,17 @@ class FillPDF : RunnableBaseExample
         // If not, there will be an `System.IO.DirectoryNotFoundException` exception.
         var wasWritten = await client.FillPdf(pdfTemplateEid, payload, "./output/fill-output.pdf");
 
+        // Version number support
+        // A version number can also be passed in. This will retrieve a specific
+        // version of the PDF to be filled if you don't want the current version
+        // to be used.
+        //
+        // You can also use the constant `ClientConstants.VERSION_LATEST` to fill a PDF with
+        // your latest, unpublished changes. Use this if you'd like to fill out a
+        // draft version of your template/PDF.
+        // var wasWritten = await client.FillPdf(pdfTemplateEid, payload, ClientConstants.VERSION_LATEST);
+
         // const outputFilepath = path.join(__dirname, '..', 'output', 'fill-output.pdf')
-        if (wasWritten)
-        {
-            Console.WriteLine("Fill PDF finished");
-        }
-        else
-        {
-            Console.WriteLine("Fill PDF did not finish successfully");
-        }
+        Console.WriteLine(wasWritten ? "Fill PDF finished" : "Fill PDF did not finish successfully");
     }
 }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.4</version>
+            <version>2.13.4.1</version>
         </dependency>
         <dependency>
             <groupId>com.github.mizosoft.methanol</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>methanol</artifactId>
             <version>1.7.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.2.1</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/java/src/main/java/com/useanvil/examples/Constants.java
+++ b/java/src/main/java/com/useanvil/examples/Constants.java
@@ -16,4 +16,13 @@ public class Constants {
     // In this case _we want_ the initial `/` because this does not use the base endpoint
     // above of `/api/v1/`.
     public static final String DownloadDocuments = "/api/document-group/%s.zip";
+
+    // Magic numbers for versions.
+    // This will use the latest version of your object (PDF templates, forges, workflows)
+    // including drafts. This is typically used to test out changes in a draft state.
+    public static final int LATEST_VERSION_INT = -1;
+
+    // This will use the latest _published_ version of your object (PDF templates, forges,
+    // workflows). This is the default if a version number isn't provided.
+    public static final int PUBLISHED_VERSION_INT = -2;
 }

--- a/java/src/main/java/com/useanvil/examples/client/RestClient.java
+++ b/java/src/main/java/com/useanvil/examples/client/RestClient.java
@@ -3,16 +3,15 @@ package com.useanvil.examples.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.useanvil.examples.Constants;
+import org.apache.hc.core5.net.URIBuilder;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Duration;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 public class RestClient extends BaseClient {
 
@@ -31,6 +30,20 @@ public class RestClient extends BaseClient {
         String fillPdfPart = String.format(Constants.FillPdf, templateId);
 
         HttpRequest request = this.createRequestBuilder(Constants.REST_ENDPOINT + fillPdfPart)
+                .POST(HttpRequest.BodyPublishers.ofString(payload))
+                .build();
+
+        return this.client.send(request, HttpResponse.BodyHandlers.ofByteArray());
+    }
+
+    public HttpResponse<byte[]> fillPdf(String templateId, String payload, int versionNumber) throws IOException, InterruptedException, URISyntaxException {
+        String fillPdfPart = String.format(Constants.FillPdf, templateId);
+
+        URI uri = new URIBuilder(new URI(Constants.REST_ENDPOINT + fillPdfPart))
+                .addParameter("versionNumber", String.valueOf(versionNumber))
+                .build();
+
+        HttpRequest request = this.createRequestBuilder(String.valueOf(uri))
                 .POST(HttpRequest.BodyPublishers.ofString(payload))
                 .build();
 

--- a/java/src/main/java/com/useanvil/examples/runnable/FillPdf.java
+++ b/java/src/main/java/com/useanvil/examples/runnable/FillPdf.java
@@ -1,8 +1,10 @@
 package com.useanvil.examples.runnable;
 
+import com.useanvil.examples.Constants;
 import com.useanvil.examples.client.RestClient;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.http.HttpResponse;
 import java.nio.file.*;
 
@@ -45,8 +47,16 @@ public class FillPdf implements IRunnable {
             // response data will be the filled PDF binary data. It is important that the
             // data is saved with no encoding! Otherwise, the PDF file will be corrupt.
             response = client.fillPdf(pdfTemplateEid, payload);
+
+            // You can also provide a version number if you'd like to fill a specific version
+            // of the template.
+            // See `Constants.LATEST_VERSION_INT` and `Constants.PUBLISHED_VERSION_INT` for more
+            // details on special version numbers.
+            // response = client.fillPdf(pdfTemplateEid, payload, Constants.LATEST_VERSION_INT);
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
+        // You will also need this catch clause if you use the `fillPdf` method that includes versionNumber.
+        // } catch (URISyntaxException e ) {
         }
 
         try {

--- a/python/examples/fill-pdf.py
+++ b/python/examples/fill-pdf.py
@@ -90,6 +90,18 @@ def main():
     # data is saved with no encoding! Otherwise, the PDF file will be corrupt.
     res = anvil.fill_pdf(PDF_TEMPLATE_EID, FILL_DATA)
 
+    # Version number support
+    # ----------------------
+    # A version number can also be passed in. This will retrieve a specific
+    # version of the PDF to be filled if you don't want the current version
+    # to be used.
+    #
+    # You can also use the constant `Anvil.VERSION_LATEST` to fill a PDF with
+    # your latest, unpublished changes. Use this if you'd like to fill out a
+    # draft version of your template/PDF.
+    #
+    # res = anvil.fill_pdf('abc123', data, version_number=Anvil.VERSION_LATEST)
+
     # Write the bytes to disk
     with open(FILE_OUTPUT, "wb") as f:
         f.write(res)

--- a/python/examples/forge_submit.py
+++ b/python/examples/forge_submit.py
@@ -1,7 +1,3 @@
-from typing import Optional
-
-from python_anvil.api_resources.mutations import BaseQuery
-from python_anvil.api_resources.payload import BaseModel
 
 DEFAULT_RESPONSE_QUERY = """
 {
@@ -41,6 +37,7 @@ FORGE_SUBMIT = """
         $groupArrayId: String,
         $groupArrayIndex: Int,
         $errorType: String,
+        $webhookURL: String,
     ) {{
         forgeSubmit (
             forgeEid: $forgeEid,
@@ -53,7 +50,8 @@ FORGE_SUBMIT = """
             timezone: $timezone,
             groupArrayId: $groupArrayId,
             groupArrayIndex: $groupArrayIndex,
-            errorType: $errorType
+            errorType: $errorType,
+            webhookURL: $webhookURL
         ) {query}
     }}
 """


### PR DESCRIPTION
* Python - Updates default forgeSubmit query
* Python - Add `version_number` docs for fill-pdf example
* Java - Update fill-pdf example with version number support
* Java - Fix CVE-2022-42003 
* C# - Fix error not being able to run examples
* C# - Update Anvil dependency version
* C# - Add more version number documentation details